### PR TITLE
Jupyter notebook support, margin height and SVG viewBox

### DIFF
--- a/example/comments.svg
+++ b/example/comments.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0, 0, 1160, 405" xmlns="http://www.w3.org/2000/svg">
 <rect fill="#1C1C1C" height="100%" width="100%"/>
 <defs>
 <clipPath id="record-clip-path-0">

--- a/example/comments.svg
+++ b/example/comments.svg
@@ -1,181 +1,181 @@
-<svg viewBox="0, 0, 1160, 405" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0, 0, 1160, 345" xmlns="http://www.w3.org/2000/svg">
 <rect fill="#1C1C1C" height="100%" width="100%"/>
 <defs>
 <clipPath id="record-clip-path-0">
-<rect height="245" rx="6" ry="6" width="300" x="50" y="80"/>
+<rect height="245" rx="6" ry="6" width="300" x="50" y="50"/>
 </clipPath>
 <clipPath id="record-clip-path-1">
-<rect height="245" rx="6" ry="6" width="300" x="430" y="80"/>
+<rect height="245" rx="6" ry="6" width="300" x="430" y="50"/>
 </clipPath>
 <clipPath id="record-clip-path-2">
-<rect height="210" rx="6" ry="6" width="300" x="810" y="80"/>
+<rect height="210" rx="6" ry="6" width="300" x="810" y="50"/>
 </clipPath>
 </defs>
-<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="50" y="80"/>
-<rect clip-path="url(#record-clip-path-0)" fill="#494949" height="35" width="300" x="50" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="97.5">
+<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="50" y="50"/>
+<rect clip-path="url(#record-clip-path-0)" fill="#494949" height="35" width="300" x="50" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="67.5">
 users
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="102.5">
 int
 </text>
-<circle cx="326.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="132.5">
+<circle cx="326.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="137.5">
 uuid
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="167.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="137.5">
 uuid
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="172.5">
 email
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="202.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="172.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="207.5">
 text
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="237.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="207.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="242.5">
 about_html
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="272.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="242.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="290" y2="290"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="307.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="260" y2="260"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="277.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="307.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="277.5">
 timestamp
 </text>
-<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="430" y="80"/>
-<rect clip-path="url(#record-clip-path-1)" fill="#494949" height="35" width="300" x="430" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="97.5">
+<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="430" y="50"/>
+<rect clip-path="url(#record-clip-path-1)" fill="#494949" height="35" width="300" x="430" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="67.5">
 posts
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="102.5">
 int
 </text>
-<circle cx="706.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="132.5">
+<circle cx="706.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="137.5">
 uuid
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="167.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="137.5">
 uuid
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="172.5">
 title
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="202.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="172.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="207.5">
 content
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="237.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="207.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="242.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="272.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="242.5">
 timestamp
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="290" y2="290"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="307.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="260" y2="260"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="277.5">
 created_by
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="307.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="277.5">
 int
 </text>
-<circle cx="706.5" cy="307.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="307.5">
+<circle cx="706.5" cy="277.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="277.5">
 FK
 </text>
-<rect fill="#212121" height="210" rx="6" ry="6" stroke="#494949" width="300" x="810" y="80"/>
-<rect clip-path="url(#record-clip-path-2)" fill="#494949" height="35" width="300" x="810" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="822" y="97.5">
+<rect fill="#212121" height="210" rx="6" ry="6" stroke="#494949" width="300" x="810" y="50"/>
+<rect clip-path="url(#record-clip-path-2)" fill="#494949" height="35" width="300" x="810" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="822" y="67.5">
 comments
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="102.5">
 int
 </text>
-<circle cx="1086.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="132.5">
+<circle cx="1086.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="137.5">
 content
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="167.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="137.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="172.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="202.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="172.5">
 timestamp
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="207.5">
 post_id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="237.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="207.5">
 int
 </text>
-<circle cx="1086.5" cy="237.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="237.5">
+<circle cx="1086.5" cy="207.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="207.5">
 FK
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="242.5">
 created_by
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="272.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="242.5">
 int
 </text>
-<circle cx="1086.5" cy="272.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="272.5">
+<circle cx="1086.5" cy="242.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="242.5">
 FK
 </text>
-<path d="M430 307.5 L396 307.5 Q390 307.5 390 301.5 L390 138.5 Q390 132.5 384 132.5 L350 132.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="430" cy="307.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="350" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<path d="M810 237.5 L776 237.5 Q770 237.5 770 231.5 L770 138.5 Q770 132.5 764 132.5 L730 132.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="810" cy="237.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="730" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<path d="M810 272.5 L776 272.5 Q770 272.5 770 278.5 L770 307.5 L770 330 L770 359 Q770 365 764 365 L580 365 L396 365 Q390 365 390 359 L390 307.5 L390 138.5 Q390 132.5 384 132.5 L350 132.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="810" cy="272.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="350" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M430 277.5 L396 277.5 Q390 277.5 390 271.5 L390 108.5 Q390 102.5 384 102.5 L350 102.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="430" cy="277.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="350" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M810 207.5 L776 207.5 Q770 207.5 770 201.5 L770 108.5 Q770 102.5 764 102.5 L730 102.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="810" cy="207.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="730" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M810 242.5 L776 242.5 Q770 242.5 770 248.5 L770 277.5 L770 300 L770 329 Q770 335 764 335 L580 335 L396 335 Q390 335 390 329 L390 277.5 L390 108.5 Q390 102.5 384 102.5 L350 102.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="810" cy="242.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="350" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
 </svg>

--- a/example/posts.svg
+++ b/example/posts.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0, 0, 1160, 405" xmlns="http://www.w3.org/2000/svg">
 <rect fill="#1C1C1C" height="100%" width="100%"/>
 <defs>
 <clipPath id="record-clip-path-0">

--- a/example/posts.svg
+++ b/example/posts.svg
@@ -1,120 +1,120 @@
-<svg viewBox="0, 0, 1160, 405" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0, 0, 1160, 345" xmlns="http://www.w3.org/2000/svg">
 <rect fill="#1C1C1C" height="100%" width="100%"/>
 <defs>
 <clipPath id="record-clip-path-0">
-<rect height="245" rx="6" ry="6" width="300" x="50" y="80"/>
+<rect height="245" rx="6" ry="6" width="300" x="50" y="50"/>
 </clipPath>
 <clipPath id="record-clip-path-1">
-<rect height="245" rx="6" ry="6" width="300" x="430" y="80"/>
+<rect height="245" rx="6" ry="6" width="300" x="430" y="50"/>
 </clipPath>
 </defs>
-<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="50" y="80"/>
-<rect clip-path="url(#record-clip-path-0)" fill="#494949" height="35" width="300" x="50" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="97.5">
+<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="50" y="50"/>
+<rect clip-path="url(#record-clip-path-0)" fill="#494949" height="35" width="300" x="50" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="67.5">
 users
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="102.5">
 int
 </text>
-<circle cx="326.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="132.5">
+<circle cx="326.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="137.5">
 uuid
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="167.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="137.5">
 uuid
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="172.5">
 email
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="202.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="172.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="207.5">
 text
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="237.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="207.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="242.5">
 about_html
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="272.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="242.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="290" y2="290"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="307.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="260" y2="260"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="277.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="307.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="277.5">
 timestamp
 </text>
-<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="430" y="80"/>
-<rect clip-path="url(#record-clip-path-1)" fill="#494949" height="35" width="300" x="430" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="97.5">
+<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="430" y="50"/>
+<rect clip-path="url(#record-clip-path-1)" fill="#494949" height="35" width="300" x="430" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="67.5">
 posts
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="102.5">
 int
 </text>
-<circle cx="706.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="132.5">
+<circle cx="706.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="137.5">
 uuid
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="167.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="137.5">
 uuid
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="172.5">
 title
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="202.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="172.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="207.5">
 content
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="237.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="207.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="242.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="272.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="242.5">
 timestamp
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="290" y2="290"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="307.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="260" y2="260"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="277.5">
 created_by
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="307.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="277.5">
 int
 </text>
-<circle cx="706.5" cy="307.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="307.5">
+<circle cx="706.5" cy="277.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="277.5">
 FK
 </text>
-<path d="M350 132.5 L384 132.5 Q390 132.5 390 138.5 L390 301.5 Q390 307.5 396 307.5 L430 307.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="350" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="430" cy="307.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M350 102.5 L384 102.5 Q390 102.5 390 108.5 L390 271.5 Q390 277.5 396 277.5 L430 277.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="350" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="430" cy="277.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
 </svg>

--- a/example/tags.svg
+++ b/example/tags.svg
@@ -1,243 +1,243 @@
-<svg viewBox="0, 0, 1160, 590" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0, 0, 1160, 530" xmlns="http://www.w3.org/2000/svg">
 <rect fill="#1C1C1C" height="100%" width="100%"/>
 <defs>
 <clipPath id="record-clip-path-0">
-<rect height="245" rx="6" ry="6" width="300" x="50" y="80"/>
+<rect height="245" rx="6" ry="6" width="300" x="50" y="50"/>
 </clipPath>
 <clipPath id="record-clip-path-1">
-<rect height="245" rx="6" ry="6" width="300" x="430" y="80"/>
+<rect height="245" rx="6" ry="6" width="300" x="430" y="50"/>
 </clipPath>
 <clipPath id="record-clip-path-2">
-<rect height="210" rx="6" ry="6" width="300" x="810" y="80"/>
+<rect height="210" rx="6" ry="6" width="300" x="810" y="50"/>
 </clipPath>
 <clipPath id="record-clip-path-3">
-<rect height="105" rx="6" ry="6" width="300" x="50" y="405"/>
+<rect height="105" rx="6" ry="6" width="300" x="50" y="375"/>
 </clipPath>
 <clipPath id="record-clip-path-4">
-<rect height="105" rx="6" ry="6" width="300" x="430" y="405"/>
+<rect height="105" rx="6" ry="6" width="300" x="430" y="375"/>
 </clipPath>
 </defs>
-<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="50" y="80"/>
-<rect clip-path="url(#record-clip-path-0)" fill="#494949" height="35" width="300" x="50" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="97.5">
+<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="50" y="50"/>
+<rect clip-path="url(#record-clip-path-0)" fill="#494949" height="35" width="300" x="50" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="67.5">
 users
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="102.5">
 int
 </text>
-<circle cx="326.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="132.5">
+<circle cx="326.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="137.5">
 uuid
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="167.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="137.5">
 uuid
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="172.5">
 email
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="202.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="172.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="207.5">
 text
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="237.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="207.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="242.5">
 about_html
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="272.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="242.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="290" y2="290"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="307.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="260" y2="260"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="277.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="307.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="277.5">
 timestamp
 </text>
-<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="430" y="80"/>
-<rect clip-path="url(#record-clip-path-1)" fill="#494949" height="35" width="300" x="430" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="97.5">
+<rect fill="#212121" height="245" rx="6" ry="6" stroke="#494949" width="300" x="430" y="50"/>
+<rect clip-path="url(#record-clip-path-1)" fill="#494949" height="35" width="300" x="430" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="67.5">
 posts
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="102.5">
 int
 </text>
-<circle cx="706.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="132.5">
+<circle cx="706.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="137.5">
 uuid
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="167.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="137.5">
 uuid
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="172.5">
 title
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="202.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="172.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="207.5">
 content
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="237.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="207.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="242.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="272.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="242.5">
 timestamp
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="290" y2="290"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="307.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="260" y2="260"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="277.5">
 created_by
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="307.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="277.5">
 int
 </text>
-<circle cx="706.5" cy="307.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="307.5">
+<circle cx="706.5" cy="277.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="277.5">
 FK
 </text>
-<rect fill="#212121" height="210" rx="6" ry="6" stroke="#494949" width="300" x="810" y="80"/>
-<rect clip-path="url(#record-clip-path-2)" fill="#494949" height="35" width="300" x="810" y="80"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="822" y="97.5">
+<rect fill="#212121" height="210" rx="6" ry="6" stroke="#494949" width="300" x="810" y="50"/>
+<rect clip-path="url(#record-clip-path-2)" fill="#494949" height="35" width="300" x="810" y="50"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="822" y="67.5">
 comments
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="115" y2="115"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="132.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="85" y2="85"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="102.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="132.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="102.5">
 int
 </text>
-<circle cx="1086.5" cy="132.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="132.5">
+<circle cx="1086.5" cy="102.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="102.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="150" y2="150"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="167.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="120" y2="120"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="137.5">
 content
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="167.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="137.5">
 text
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="185" y2="185"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="202.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="155" y2="155"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="172.5">
 created_at
 </text>
-<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="202.5">
+<text dominant-baseline="middle" fill="#06B697" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="172.5">
 timestamp
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="220" y2="220"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="237.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="190" y2="190"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="207.5">
 post_id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="237.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="207.5">
 int
 </text>
-<circle cx="1086.5" cy="237.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="237.5">
+<circle cx="1086.5" cy="207.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="207.5">
 FK
 </text>
-<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="255" y2="255"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="272.5">
+<line stroke="#494949" stroke-width="1" x1="810" x2="1110" y1="225" y2="225"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="822" y="242.5">
 created_by
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="272.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="1050" y="242.5">
 int
 </text>
-<circle cx="1086.5" cy="272.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="272.5">
+<circle cx="1086.5" cy="242.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="1086.5" y="242.5">
 FK
 </text>
-<rect fill="#212121" height="105" rx="6" ry="6" stroke="#494949" width="300" x="50" y="405"/>
-<rect clip-path="url(#record-clip-path-3)" fill="#494949" height="35" width="300" x="50" y="405"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="422.5">
+<rect fill="#212121" height="105" rx="6" ry="6" stroke="#494949" width="300" x="50" y="375"/>
+<rect clip-path="url(#record-clip-path-3)" fill="#494949" height="35" width="300" x="50" y="375"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="62" y="392.5">
 tags
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="440" y2="440"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="457.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="410" y2="410"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="427.5">
 id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="457.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="427.5">
 int
 </text>
-<circle cx="326.5" cy="457.5" fill="#373737" r="11.5"/>
-<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="457.5">
+<circle cx="326.5" cy="427.5" fill="#373737" r="11.5"/>
+<text dominant-baseline="middle" fill="white" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="326.5" y="427.5">
 PK
 </text>
-<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="475" y2="475"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="492.5">
+<line stroke="#494949" stroke-width="1" x1="50" x2="350" y1="445" y2="445"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="62" y="462.5">
 name
 </text>
-<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="492.5">
+<text dominant-baseline="middle" fill="#D66905" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="290" y="462.5">
 text
 </text>
-<rect fill="#212121" height="105" rx="6" ry="6" stroke="#494949" width="300" x="430" y="405"/>
-<rect clip-path="url(#record-clip-path-4)" fill="#494949" height="35" width="300" x="430" y="405"/>
-<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="422.5">
+<rect fill="#212121" height="105" rx="6" ry="6" stroke="#494949" width="300" x="430" y="375"/>
+<rect clip-path="url(#record-clip-path-4)" fill="#494949" height="35" width="300" x="430" y="375"/>
+<text dominant-baseline="middle" fill="white" font-family="Monaco,Lucida Console,monospace" font-weight="bold" text-anchor="start" x="442" y="392.5">
 post_tags
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="440" y2="440"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="457.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="410" y2="410"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="427.5">
 post_id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="457.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="427.5">
 int
 </text>
-<circle cx="706.5" cy="457.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="457.5">
+<circle cx="706.5" cy="427.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="427.5">
 FK
 </text>
-<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="475" y2="475"/>
-<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="492.5">
+<line stroke="#494949" stroke-width="1" x1="430" x2="730" y1="445" y2="445"/>
+<text dominant-baseline="middle" fill="white" font-family="Courier New,monospace" font-weight="lighter" text-anchor="start" x="442" y="462.5">
 tag_id
 </text>
-<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="492.5">
+<text dominant-baseline="middle" fill="#ECC700" font-family="Courier New,monospace" font-size="small" font-weight="lighter" text-anchor="end" x="670" y="462.5">
 int
 </text>
-<circle cx="706.5" cy="492.5" fill="#202937" r="11.5"/>
-<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="492.5">
+<circle cx="706.5" cy="462.5" fill="#202937" r="11.5"/>
+<text dominant-baseline="middle" fill="#1170FB" font-family="Trebuchet MS,sans-serif" font-size="xx-small" text-anchor="middle" x="706.5" y="462.5">
 FK
 </text>
-<path d="M430 307.5 L396 307.5 Q390 307.5 390 301.5 L390 138.5 Q390 132.5 384 132.5 L350 132.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="430" cy="307.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="350" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<path d="M810 237.5 L776 237.5 Q770 237.5 770 231.5 L770 138.5 Q770 132.5 764 132.5 L730 132.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="810" cy="237.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="730" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<path d="M810 272.5 L776 272.5 Q770 272.5 770 278.5 L770 307.5 L770 330 L770 359 Q770 365 764 365 L580 365 L396 365 Q390 365 390 359 L390 307.5 L390 138.5 Q390 132.5 384 132.5 L350 132.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="810" cy="272.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="350" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<path d="M730 457.5 L764 457.5 Q770 457.5 770 451.5 L770 365 L770 330 L770 307.5 L770 272.5 L770 237.5 L770 138.5 Q770 132.5 764 132.5 L730 132.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="730" cy="457.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="730" cy="132.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<path d="M430 492.5 L396 492.5 Q390 492.5 390 486.5 L390 463.5 Q390 457.5 384 457.5 L350 457.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
-<circle cx="430" cy="492.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
-<circle cx="350" cy="457.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M430 277.5 L396 277.5 Q390 277.5 390 271.5 L390 108.5 Q390 102.5 384 102.5 L350 102.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="430" cy="277.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="350" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M810 207.5 L776 207.5 Q770 207.5 770 201.5 L770 108.5 Q770 102.5 764 102.5 L730 102.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="810" cy="207.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="730" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M810 242.5 L776 242.5 Q770 242.5 770 248.5 L770 277.5 L770 300 L770 329 Q770 335 764 335 L580 335 L396 335 Q390 335 390 329 L390 277.5 L390 108.5 Q390 102.5 384 102.5 L350 102.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="810" cy="242.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="350" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M730 427.5 L764 427.5 Q770 427.5 770 421.5 L770 335 L770 300 L770 277.5 L770 242.5 L770 207.5 L770 108.5 Q770 102.5 764 102.5 L730 102.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="730" cy="427.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="730" cy="102.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<path d="M430 462.5 L396 462.5 Q390 462.5 390 456.5 L390 433.5 Q390 427.5 384 427.5 L350 427.5" fill="transparent" stroke="#888888" stroke-width="1.5"/>
+<circle cx="430" cy="462.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
+<circle cx="350" cy="427.5" fill="#1C1C1C" r="4" stroke="#888888" stroke-width="1.5"/>
 </svg>

--- a/example/tags.svg
+++ b/example/tags.svg
@@ -1,4 +1,4 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0, 0, 1160, 590" xmlns="http://www.w3.org/2000/svg">
 <rect fill="#1C1C1C" height="100%" width="100%"/>
 <defs>
 <clipPath id="record-clip-path-0">

--- a/src/evcxr.rs
+++ b/src/evcxr.rs
@@ -1,0 +1,43 @@
+//! Evcxr extension
+use crate::{
+    geometry::Rect,
+    mir,
+    renderer::{Renderer, SVGRenderer},
+};
+
+/// See https://github.com/google/evcxr/blob/main/evcxr_jupyter/README.md#custom-output
+pub trait CustomDisplay {
+    fn evcxr_display(&self);
+}
+
+pub struct SVGOutput {
+    svg: String,
+}
+
+impl SVGOutput {
+    pub fn new(svg: String) -> Self {
+        Self { svg }
+    }
+}
+
+impl CustomDisplay for SVGOutput {
+    fn evcxr_display(&self) {
+        println!(
+            "EVCXR_BEGIN_CONTENT image/svg+xml\n{}\nEVCXR_END_CONTENT",
+            self.svg
+        );
+    }
+}
+
+pub fn draw_erd(doc: &mir::Document, view_box: Option<Rect>) -> impl CustomDisplay {
+    let mut backend: SVGRenderer = SVGRenderer::new();
+    let mut bytes: Vec<u8> = vec![];
+
+    backend.view_box = view_box;
+    backend
+        .render(&doc, &mut bytes)
+        .expect("cannot generate SVG");
+
+    let svg = String::from_utf8(bytes).unwrap();
+    SVGOutput::new(svg)
+}

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -201,7 +201,7 @@ impl SimpleLayoutEngine {
 }
 
 impl SimpleLayoutEngine {
-    const ORIGIN: Point = Point::new(50.0, 50.0);
+    const ORIGIN: Point = Point::new(50.0, 80.0);
     const LINE_HEIGHT: f32 = 35.0;
     const RECORD_WIDTH: f32 = 300.0;
     const RECORD_SPACE: f32 = 80.0;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -201,7 +201,7 @@ impl SimpleLayoutEngine {
 }
 
 impl SimpleLayoutEngine {
-    const ORIGIN: Point = Point::new(50.0, 80.0);
+    const ORIGIN: Point = Point::new(50.0, 50.0);
     const LINE_HEIGHT: f32 = 35.0;
     const RECORD_WIDTH: f32 = 300.0;
     const RECORD_SPACE: f32 = 80.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod layout;
 pub mod mir;
 pub mod parser;
 pub mod renderer;
+pub mod evcxr;
 
 #[cfg(test)]
 mod tests {
@@ -37,7 +38,7 @@ mod tests {
 
         assert_diff!(
             svg.as_str(), 
-            "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n<rect fill=\"#1C1C1C\" height=\"100%\" width=\"100%\"/>\n<defs/>\n</svg>", 
+            "<svg xmlns=\"http://www.w3.org/2000/svg\">\n<rect fill=\"#1C1C1C\" height=\"100%\" width=\"100%\"/>\n<defs/>\n</svg>", 
             "\n",
             0);
     }
@@ -127,7 +128,7 @@ mod tests {
             .expect("cannot generate SVG");
 
         let svg = String::from_utf8(bytes).unwrap();
-        assert_diff!(svg.as_str(), "<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">
+        assert_diff!(svg.as_str(), "<svg xmlns=\"http://www.w3.org/2000/svg\">
 <rect fill=\"#1C1C1C\" height=\"100%\" width=\"100%\"/>
 <defs>
 <clipPath id=\"record-clip-path-0\">
@@ -269,11 +270,13 @@ FK
             let mut doc = ast.unwrap().into_mir();
             let mut engine = SimpleLayoutEngine::new();
 
-            engine.place_nodes(&mut doc);
+            let view_box = engine.place_nodes(&mut doc);
             engine.place_terminal_ports(&mut doc);
             engine.draw_edge_path(&mut doc);
 
-            let backend = SVGRenderer::new();
+            let mut backend = SVGRenderer::new();
+            backend.view_box = view_box;
+
             let mut bytes: Vec<u8> = vec![];
     
             backend

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,118 +128,120 @@ mod tests {
             .expect("cannot generate SVG");
 
         let svg = String::from_utf8(bytes).unwrap();
+
+        eprintln!("{}", svg);
         assert_diff!(svg.as_str(), "<svg xmlns=\"http://www.w3.org/2000/svg\">
 <rect fill=\"#1C1C1C\" height=\"100%\" width=\"100%\"/>
 <defs>
 <clipPath id=\"record-clip-path-0\">
-<rect height=\"210\" rx=\"6\" ry=\"6\" width=\"300\" x=\"50\" y=\"80\"/>
+<rect height=\"210\" rx=\"6\" ry=\"6\" width=\"300\" x=\"50\" y=\"50\"/>
 </clipPath>
 <clipPath id=\"record-clip-path-1\">
-<rect height=\"245\" rx=\"6\" ry=\"6\" width=\"300\" x=\"430\" y=\"80\"/>
+<rect height=\"245\" rx=\"6\" ry=\"6\" width=\"300\" x=\"430\" y=\"50\"/>
 </clipPath>
 </defs>
-<rect fill=\"#212121\" height=\"210\" rx=\"6\" ry=\"6\" stroke=\"#494949\" width=\"300\" x=\"50\" y=\"80\"/>
-<rect clip-path=\"url(#record-clip-path-0)\" fill=\"#494949\" height=\"35\" width=\"300\" x=\"50\" y=\"80\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Monaco,Lucida Console,monospace\" font-weight=\"bold\" text-anchor=\"start\" x=\"62\" y=\"97.5\">
+<rect fill=\"#212121\" height=\"210\" rx=\"6\" ry=\"6\" stroke=\"#494949\" width=\"300\" x=\"50\" y=\"50\"/>
+<rect clip-path=\"url(#record-clip-path-0)\" fill=\"#494949\" height=\"35\" width=\"300\" x=\"50\" y=\"50\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Monaco,Lucida Console,monospace\" font-weight=\"bold\" text-anchor=\"start\" x=\"62\" y=\"67.5\">
 users
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"115\" y2=\"115\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"132.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"85\" y2=\"85\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"102.5\">
 id
 </text>
-<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"132.5\">
+<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"102.5\">
 int
 </text>
-<circle cx=\"326.5\" cy=\"132.5\" fill=\"#373737\" r=\"11.5\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Trebuchet MS,sans-serif\" font-size=\"xx-small\" text-anchor=\"middle\" x=\"326.5\" y=\"132.5\">
+<circle cx=\"326.5\" cy=\"102.5\" fill=\"#373737\" r=\"11.5\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Trebuchet MS,sans-serif\" font-size=\"xx-small\" text-anchor=\"middle\" x=\"326.5\" y=\"102.5\">
 PK
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"150\" y2=\"150\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"167.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"120\" y2=\"120\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"137.5\">
 uuid
 </text>
-<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"167.5\">
+<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"137.5\">
 uuid
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"185\" y2=\"185\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"202.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"155\" y2=\"155\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"172.5\">
 email
 </text>
-<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"202.5\">
+<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"172.5\">
 text
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"220\" y2=\"220\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"237.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"190\" y2=\"190\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"207.5\">
 about_html
 </text>
-<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"237.5\">
+<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"207.5\">
 text
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"255\" y2=\"255\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"272.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"50\" x2=\"350\" y1=\"225\" y2=\"225\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"62\" y=\"242.5\">
 created_at
 </text>
-<text dominant-baseline=\"middle\" fill=\"#06B697\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"272.5\">
+<text dominant-baseline=\"middle\" fill=\"#06B697\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"290\" y=\"242.5\">
 timestamp
 </text>
-<rect fill=\"#212121\" height=\"245\" rx=\"6\" ry=\"6\" stroke=\"#494949\" width=\"300\" x=\"430\" y=\"80\"/>
-<rect clip-path=\"url(#record-clip-path-1)\" fill=\"#494949\" height=\"35\" width=\"300\" x=\"430\" y=\"80\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Monaco,Lucida Console,monospace\" font-weight=\"bold\" text-anchor=\"start\" x=\"442\" y=\"97.5\">
+<rect fill=\"#212121\" height=\"245\" rx=\"6\" ry=\"6\" stroke=\"#494949\" width=\"300\" x=\"430\" y=\"50\"/>
+<rect clip-path=\"url(#record-clip-path-1)\" fill=\"#494949\" height=\"35\" width=\"300\" x=\"430\" y=\"50\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Monaco,Lucida Console,monospace\" font-weight=\"bold\" text-anchor=\"start\" x=\"442\" y=\"67.5\">
 posts
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"115\" y2=\"115\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"132.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"85\" y2=\"85\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"102.5\">
 id
 </text>
-<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"132.5\">
+<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"102.5\">
 int
 </text>
-<circle cx=\"706.5\" cy=\"132.5\" fill=\"#373737\" r=\"11.5\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Trebuchet MS,sans-serif\" font-size=\"xx-small\" text-anchor=\"middle\" x=\"706.5\" y=\"132.5\">
+<circle cx=\"706.5\" cy=\"102.5\" fill=\"#373737\" r=\"11.5\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Trebuchet MS,sans-serif\" font-size=\"xx-small\" text-anchor=\"middle\" x=\"706.5\" y=\"102.5\">
 PK
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"150\" y2=\"150\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"167.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"120\" y2=\"120\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"137.5\">
 uuid
 </text>
-<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"167.5\">
+<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"137.5\">
 uuid
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"185\" y2=\"185\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"202.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"155\" y2=\"155\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"172.5\">
 title
 </text>
-<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"202.5\">
+<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"172.5\">
 text
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"220\" y2=\"220\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"237.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"190\" y2=\"190\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"207.5\">
 content
 </text>
-<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"237.5\">
+<text dominant-baseline=\"middle\" fill=\"#D66905\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"207.5\">
 text
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"255\" y2=\"255\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"272.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"225\" y2=\"225\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"242.5\">
 created_at
 </text>
-<text dominant-baseline=\"middle\" fill=\"#06B697\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"272.5\">
+<text dominant-baseline=\"middle\" fill=\"#06B697\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"242.5\">
 timestamp
 </text>
-<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"290\" y2=\"290\"/>
-<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"307.5\">
+<line stroke=\"#494949\" stroke-width=\"1\" x1=\"430\" x2=\"730\" y1=\"260\" y2=\"260\"/>
+<text dominant-baseline=\"middle\" fill=\"white\" font-family=\"Courier New,monospace\" font-weight=\"lighter\" text-anchor=\"start\" x=\"442\" y=\"277.5\">
 created_by
 </text>
-<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"307.5\">
+<text dominant-baseline=\"middle\" fill=\"#ECC700\" font-family=\"Courier New,monospace\" font-size=\"small\" font-weight=\"lighter\" text-anchor=\"end\" x=\"670\" y=\"277.5\">
 int
 </text>
-<circle cx=\"706.5\" cy=\"307.5\" fill=\"#202937\" r=\"11.5\"/>
-<text dominant-baseline=\"middle\" fill=\"#1170FB\" font-family=\"Trebuchet MS,sans-serif\" font-size=\"xx-small\" text-anchor=\"middle\" x=\"706.5\" y=\"307.5\">
+<circle cx=\"706.5\" cy=\"277.5\" fill=\"#202937\" r=\"11.5\"/>
+<text dominant-baseline=\"middle\" fill=\"#1170FB\" font-family=\"Trebuchet MS,sans-serif\" font-size=\"xx-small\" text-anchor=\"middle\" x=\"706.5\" y=\"277.5\">
 FK
 </text>
-<path d=\"M430 307.5 L396 307.5 Q390 307.5 390 301.5 L390 138.5 Q390 132.5 384 132.5 L350 132.5\" fill=\"transparent\" stroke=\"#888888\" stroke-width=\"1.5\"/>
-<circle cx=\"430\" cy=\"307.5\" fill=\"#1C1C1C\" r=\"4\" stroke=\"#888888\" stroke-width=\"1.5\"/>
-<circle cx=\"350\" cy=\"132.5\" fill=\"#1C1C1C\" r=\"4\" stroke=\"#888888\" stroke-width=\"1.5\"/>
+<path d=\"M430 277.5 L396 277.5 Q390 277.5 390 271.5 L390 108.5 Q390 102.5 384 102.5 L350 102.5\" fill=\"transparent\" stroke=\"#888888\" stroke-width=\"1.5\"/>
+<circle cx=\"430\" cy=\"277.5\" fill=\"#1C1C1C\" r=\"4\" stroke=\"#888888\" stroke-width=\"1.5\"/>
+<circle cx=\"350\" cy=\"102.5\" fill=\"#1C1C1C\" r=\"4\" stroke=\"#888888\" stroke-width=\"1.5\"/>
 </svg>", "\n", 0);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,11 +110,13 @@ fn main() -> Result<(), io::Error> {
         let mut doc = ast.into_mir();
         let mut engine = SimpleLayoutEngine::new();
 
-        engine.place_nodes(&mut doc);
+        let view_box = engine.place_nodes(&mut doc);
+
         engine.place_terminal_ports(&mut doc);
         engine.draw_edge_path(&mut doc);
 
         let mut backend = SVGRenderer::new();
+        backend.view_box = view_box;
 
         if DEBUG {
             backend.edge_route_graph = Some(engine.edge_route_graph());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,7 +71,9 @@ pub enum Token {
     Newline,
 }
 
-pub fn parse(src: &str) -> (Option<Module>, Vec<Simple<char>>, Vec<Simple<Token>>) {
+pub type ParseResult = (Option<Module>, Vec<Simple<char>>, Vec<Simple<Token>>);
+
+pub fn parse(src: &str) -> ParseResult {
     let (tokens, errs) = tokenizer().parse_recovery(src);
 
     if let Some(tokens) = tokens {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -624,7 +624,7 @@ impl SVGRenderer<'_> {
                     .set("stroke", "white")
                     .set("stroke-width", 1)
                     .set("fill", "orange");
-                svg_doc = svg_doc.add(circle);
+                svg_doc.append(circle);
             }
         }
 
@@ -643,7 +643,7 @@ impl SVGRenderer<'_> {
                 .set("font-size", 12)
                 .set("font-family", "monospace")
                 .add(svg::node::Text::new(id.to_string()));
-            svg_doc = svg_doc.add(label);
+            svg_doc.append(label);
         }
 
         svg_doc

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -35,7 +35,7 @@ impl Renderer for SVGRenderer<'_> {
         let background_color = WebColor::RGB(RGBColor::new(28, 28, 28));
 
         // -- Build a SVG document
-        let mut svg_doc = svg::Document::new().set("version", "1.1");
+        let mut svg_doc = svg::Document::new();
         let mut svg_defs = element::Definitions::new();
 
         // -- Background

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -2,12 +2,12 @@
 use crate::{
     color::{RGBColor, WebColor},
     error::BackendError,
-    geometry::{Orientation, Point},
+    geometry::{Orientation, Point, Rect},
     layout::RouteGraph,
     mir,
 };
 use std::io::Write;
-use svg::node::element;
+use svg::{node::element, Node};
 
 pub trait Renderer {
     fn render(&self, doc: &mir::Document, writer: &mut impl Write) -> Result<(), BackendError>;
@@ -15,6 +15,9 @@ pub trait Renderer {
 
 #[derive(Debug)]
 pub struct SVGRenderer<'g> {
+    // SVG viewBox
+    pub view_box: Option<Rect>,
+
     // for debug
     pub edge_route_graph: Option<&'g RouteGraph>,
 }
@@ -22,6 +25,7 @@ pub struct SVGRenderer<'g> {
 impl SVGRenderer<'_> {
     pub fn new() -> Self {
         Self {
+            view_box: None,
             edge_route_graph: None,
         }
     }
@@ -38,13 +42,26 @@ impl Renderer for SVGRenderer<'_> {
         let mut svg_doc = svg::Document::new();
         let mut svg_defs = element::Definitions::new();
 
+        if let Some(view_box) = self.view_box {
+            svg_doc.assign(
+                "viewBox",
+                format!(
+                    "{}, {}, {}, {}",
+                    view_box.min_x(),
+                    view_box.min_y(),
+                    view_box.width(),
+                    view_box.height()
+                ),
+            );
+        }
+
         // -- Background
         let background_rect = element::Rectangle::new()
             .set("width", "100%")
             .set("height", "100%")
             .set("fill", background_color.to_string());
 
-        svg_doc = svg_doc.add(background_rect);
+        svg_doc.append(background_rect);
 
         // -- Generate clip paths for record shapes.
         for (record_index, child_id) in doc.body().children().enumerate() {
@@ -65,9 +82,9 @@ impl Renderer for SVGRenderer<'_> {
             let id = format!("{}{}", record_clip_path_id_prefix, record_index);
             let clip_path = element::ClipPath::new().set("id", id).add(clip_path_rect);
 
-            svg_defs = svg_defs.add(clip_path);
+            svg_defs.append(clip_path);
         }
-        svg_doc = svg_doc.add(svg_defs);
+        svg_doc.append(svg_defs);
 
         // -- Draw shapes
         for (record_index, child_id) in doc.body().children().enumerate() {
@@ -85,12 +102,12 @@ impl Renderer for SVGRenderer<'_> {
                 .set("rx", border_radius)
                 .set("ry", border_radius);
             if let Some(border_color) = &record.border_color {
-                table_bg = table_bg.set("stroke", border_color.to_string());
+                table_bg.assign("stroke", border_color.to_string());
             }
             if let Some(bg_color) = &record.bg_color {
-                table_bg = table_bg.set("fill", bg_color.to_string());
+                table_bg.assign("fill", bg_color.to_string());
             }
-            svg_doc = svg_doc.add(table_bg);
+            svg_doc.append(table_bg);
 
             // children
             let record_clip_path_id = format!("{}{}", record_clip_path_id_prefix, record_index);
@@ -112,7 +129,7 @@ impl Renderer for SVGRenderer<'_> {
                         .set("height", field_rect.height())
                         .set("fill", bg_color.to_string())
                         .set("clip-path", format!("url(#{})", record_clip_path_id));
-                    svg_doc = svg_doc.add(field_bg);
+                    svg_doc.append(field_bg);
                 }
 
                 // border
@@ -127,7 +144,7 @@ impl Renderer for SVGRenderer<'_> {
                             .set("stroke", border_color.to_string())
                             .set("stroke-width", 1);
                     }
-                    svg_doc = svg_doc.add(line);
+                    svg_doc.append(line);
                 }
 
                 // Renders text elements
@@ -146,7 +163,7 @@ impl Renderer for SVGRenderer<'_> {
                     Point::new(x + px, field_rect.mid_y()),
                     Some(SVGAnchor::Start),
                 );
-                svg_doc = svg_doc.add(text_element);
+                svg_doc.append(text_element);
 
                 // subtitle
                 if let Some(subtitle) = &field.subtitle {
@@ -155,7 +172,7 @@ impl Renderer for SVGRenderer<'_> {
                         Point::new(x + column_width * 4.0, field_rect.mid_y()),
                         Some(SVGAnchor::End),
                     );
-                    svg_doc = svg_doc.add(text_element);
+                    svg_doc.append(text_element);
                 }
 
                 // badge
@@ -170,7 +187,7 @@ impl Renderer for SVGRenderer<'_> {
                             .set("cy", cy)
                             .set("r", bg_radius)
                             .set("fill", bg_color.to_string());
-                        svg_doc = svg_doc.add(bg_element);
+                        svg_doc.append(bg_element);
                     }
 
                     let text_element = self.draw_text(
@@ -178,7 +195,7 @@ impl Renderer for SVGRenderer<'_> {
                         Point::new(rx - bg_radius, cy),
                         Some(SVGAnchor::Middle),
                     );
-                    svg_doc = svg_doc.add(text_element);
+                    svg_doc.append(text_element);
                 }
             }
         }


### PR DESCRIPTION
This pull request makes the following changes:

- Adds support for rendering in Jupyter notebooks
- Adjusts the margin height for better visual aesthetics
- Sets the viewBox attribute for SVG output for improved rendering
- Removes the version attribute from SVG output as it is deprecated